### PR TITLE
Add targeted patch tool for Evernote notes

### DIFF
--- a/__tests__/integration/mcp-tools.test.ts
+++ b/__tests__/integration/mcp-tools.test.ts
@@ -79,7 +79,7 @@ describe('MCP Tools Integration', () => {
       
       expect(result).toHaveProperty('tools');
       expect(Array.isArray(result.tools)).toBe(true);
-      expect(result.tools).toHaveLength(11);
+      expect(result.tools).toHaveLength(28);
       
       const toolNames = result.tools.map((tool: any) => tool.name);
       expect(toolNames).toContain('evernote_create_note');
@@ -93,6 +93,7 @@ describe('MCP Tools Integration', () => {
       expect(toolNames).toContain('evernote_create_tag');
       expect(toolNames).toContain('evernote_get_user_info');
       expect(toolNames).toContain('evernote_health_check');
+      expect(toolNames).toContain('evernote_patch_note');
     });
 
     it('should include proper tool schemas', async () => {
@@ -906,6 +907,53 @@ describe('MCP Tools Integration', () => {
       };
 
       await expect(callToolHandler(request)).rejects.toThrow('At least one replacement must be provided');
+    });
+
+    it('should throw error when find string is empty', async () => {
+      const request = {
+        params: {
+          name: 'evernote_patch_note',
+          arguments: {
+            guid: 'note-123',
+            replacements: [
+              { find: '', replace: 'replacement' }
+            ]
+          }
+        }
+      };
+
+      await expect(callToolHandler(request)).rejects.toThrow('Each replacement must have a non-empty "find" string');
+    });
+
+    it('should preserve existing resources after patch', async () => {
+      const noteWithResources = {
+        ...sampleNote,
+        content: '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note>Status: Pending</en-note>',
+        resources: [sampleResource]
+      };
+      mockNoteStore.getNote.mockResolvedValue(noteWithResources);
+      mockNoteStore.updateNote.mockImplementation((note: any) => {
+        // Verify resources are preserved
+        expect(note.resources).toBeDefined();
+        expect(note.resources.length).toBeGreaterThan(0);
+        return Promise.resolve(note);
+      });
+
+      const request = {
+        params: {
+          name: 'evernote_patch_note',
+          arguments: {
+            guid: 'note-123',
+            replacements: [
+              { find: 'Status: Pending', replace: 'Status: Complete' }
+            ]
+          }
+        }
+      };
+
+      const result = await callToolHandler(request);
+
+      expect(result.content[0].text).toContain('Note patched successfully');
     });
 
     it('should handle note not found error', async () => {

--- a/__tests__/unit/search-preview.test.ts
+++ b/__tests__/unit/search-preview.test.ts
@@ -17,13 +17,13 @@ function enmlToPlainText(enmlContent: string): string {
   // Remove all remaining HTML/XML tags
   text = text.replace(/<[^>]+>/g, '');
 
-  // Decode common HTML entities
+  // Decode common HTML entities (decode &amp; LAST to avoid double-unescaping)
   text = text.replace(/&nbsp;/gi, ' ');
-  text = text.replace(/&amp;/gi, '&');
   text = text.replace(/&lt;/gi, '<');
   text = text.replace(/&gt;/gi, '>');
   text = text.replace(/&quot;/gi, '"');
   text = text.replace(/&#39;/gi, "'");
+  text = text.replace(/&amp;/gi, '&');
 
   // Normalize whitespace
   text = text.replace(/\n\s*\n/g, '\n');

--- a/src/evernote-api.ts
+++ b/src/evernote-api.ts
@@ -128,13 +128,13 @@ export class EvernoteAPI {
     // Remove all remaining HTML/XML tags
     text = text.replace(/<[^>]+>/g, '');
 
-    // Decode common HTML entities
+    // Decode common HTML entities (decode &amp; LAST to avoid double-unescaping)
     text = text.replace(/&nbsp;/gi, ' ');
-    text = text.replace(/&amp;/gi, '&');
     text = text.replace(/&lt;/gi, '<');
     text = text.replace(/&gt;/gi, '>');
     text = text.replace(/&quot;/gi, '"');
     text = text.replace(/&#39;/gi, "'");
+    text = text.replace(/&amp;/gi, '&');
 
     // Normalize whitespace
     text = text.replace(/\n\s*\n/g, '\n');

--- a/src/evernote-api.ts
+++ b/src/evernote-api.ts
@@ -196,6 +196,27 @@ export class EvernoteAPI {
   }
 
   async patchNoteContent(guid: string, replacements: NoteReplacement[]): Promise<PatchNoteResult> {
+    // Validate inputs before performing I/O
+    if (!replacements || replacements.length === 0) {
+      return {
+        success: false,
+        noteGuid: guid,
+        changes: [],
+        warning: 'No replacements provided',
+      };
+    }
+
+    for (const replacement of replacements) {
+      if (!replacement.find || typeof replacement.find !== 'string' || replacement.find.length === 0) {
+        return {
+          success: false,
+          noteGuid: guid,
+          changes: [],
+          warning: 'Empty find string in replacements',
+        };
+      }
+    }
+
     // Fetch existing note with content and resources
     const note = await this.getNote(guid, true, true);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1393,6 +1393,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new Error('At least one replacement must be provided');
         }
 
+        // Validate each replacement has a non-empty find string
+        for (const r of replacements) {
+          if (!r.find || typeof r.find !== 'string' || r.find.length === 0) {
+            throw new Error('Each replacement must have a non-empty "find" string');
+          }
+        }
+
         const result = await evernoteApi.patchNoteContent(guid, replacements);
 
         // Format the response

--- a/src/index.ts
+++ b/src/index.ts
@@ -714,6 +714,44 @@ const tools: Tool[] = [
       required: ['guid'],
     },
   },
+  // Patch note tool for targeted find-and-replace updates
+  {
+    name: 'evernote_patch_note',
+    description: 'Apply targeted find-and-replace edits to a note without regenerating full content. Useful for updating specific text like status fields, dates, or labels while preserving the rest of the note.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        guid: {
+          type: 'string',
+          description: 'Note GUID',
+        },
+        replacements: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              find: {
+                type: 'string',
+                description: 'Text to find (exact match)',
+              },
+              replace: {
+                type: 'string',
+                description: 'Replacement text',
+              },
+              replaceAll: {
+                type: 'boolean',
+                description: 'Replace all occurrences (default: true)',
+                default: true,
+              },
+            },
+            required: ['find', 'replace'],
+          },
+          description: 'Array of find-and-replace operations to apply',
+        },
+      },
+      required: ['guid', 'replacements'],
+    },
+  },
 ];
 
 // List tools handler
@@ -1346,6 +1384,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             },
           ],
         };
+      }
+
+      case 'evernote_patch_note': {
+        const { guid, replacements } = args as any;
+
+        if (!replacements || !Array.isArray(replacements) || replacements.length === 0) {
+          throw new Error('At least one replacement must be provided');
+        }
+
+        const result = await evernoteApi.patchNoteContent(guid, replacements);
+
+        // Format the response
+        const changesSummary = result.changes
+          .map(c => `  • "${c.find}" → found ${c.occurrences}x, replaced ${c.replaced}x`)
+          .join('\n');
+
+        if (result.success) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `✅ Note patched successfully!\nGUID: ${result.noteGuid}\n\nChanges:\n${changesSummary}`,
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `⚠️ Note patch failed\nGUID: ${result.noteGuid}\nReason: ${result.warning}\n\nAttempted changes:\n${changesSummary}`,
+              },
+            ],
+          };
+        }
       }
 
       case 'evernote_health_check': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,3 +193,20 @@ export interface ResourceInfo {
   hash: string;
   hasRecognition: boolean;
 }
+
+export interface NoteReplacement {
+  find: string;
+  replace: string;
+  replaceAll?: boolean;
+}
+
+export interface PatchNoteResult {
+  success: boolean;
+  noteGuid: string;
+  changes: Array<{
+    find: string;
+    occurrences: number;
+    replaced: number;
+  }>;
+  warning?: string;
+}


### PR DESCRIPTION
Introduces the 'evernote_patch_note' tool for applying targeted find-and-replace operations to note content without regenerating the entire note. Implements backend logic in EvernoteAPI, updates types for replacements and patch results, and adds comprehensive integration tests for various patching scenarios.