### PR TITLE
chore: ignore MCP registry token files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ junit.xml
 test-results/
 cc-working-*/
 cc-out-*/
+.mcpregistry_registry_token
+.mcpregistry_github_token


### PR DESCRIPTION
## Summary
- Ignore local MCP Registry token files so they cannot be staged accidentally
- Replaces the still-relevant gitignore portion of closed PR #23 without carrying its obsolete error-handler changes

## Verification
- npm run lint
- npm run build
- npm test -- --runInBand
- npm audit --omit=dev