### PR TITLE
fix(polling): use filtered Evernote sync chunks

### DIFF
--- a/__tests__/mocks/evernote.mock.ts
+++ b/__tests__/mocks/evernote.mock.ts
@@ -23,7 +23,7 @@ export const mockNoteStore = {
   updateTag: jest.fn() as jest.MockedFunction<any>,
   expungeTag: jest.fn() as jest.MockedFunction<any>,
   getSyncState: jest.fn() as jest.MockedFunction<any>,
-  getSyncChunk: jest.fn() as jest.MockedFunction<any>,
+  getFilteredSyncChunk: jest.fn() as jest.MockedFunction<any>,
   // Resource operations
   getResource: jest.fn() as jest.MockedFunction<any>,
   getResourceRecognition: jest.fn() as jest.MockedFunction<any>,
@@ -71,6 +71,7 @@ export const mockEvernoteTypes = {
 };
 
 export const mockEvernoteNoteStore = {
+  SyncChunkFilter: jest.fn().mockImplementation(filter => ({ ...filter })),
   NoteFilter: jest.fn().mockImplementation(() => ({
     words: '',
     notebookGuid: null,

--- a/__tests__/mocks/evernote.mock.ts
+++ b/__tests__/mocks/evernote.mock.ts
@@ -71,7 +71,11 @@ export const mockEvernoteTypes = {
 };
 
 export const mockEvernoteNoteStore = {
-  SyncChunkFilter: jest.fn().mockImplementation(filter => ({ ...filter })),
+  SyncChunkFilter: jest
+    .fn()
+    .mockImplementation((filter: unknown) =>
+      filter && typeof filter === 'object' ? { ...filter } : {}
+    ),
   NoteFilter: jest.fn().mockImplementation(() => ({
     words: '',
     notebookGuid: null,
@@ -113,7 +117,8 @@ mockEvernoteClient.getUserStore.mockReturnValue(mockUserStore);
 export const sampleNote = {
   guid: 'note-guid-123',
   title: 'Test Note',
-  content: '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note>Test content</en-note>',
+  content:
+    '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note>Test content</en-note>',
   created: Date.now(),
   updated: Date.now(),
   tagNames: ['test-tag'],
@@ -140,7 +145,8 @@ export const sampleNoteMetadata = {
 export const sampleNoteWithLongContent = {
   guid: 'note-guid-123',
   title: 'Test Note',
-  content: '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>This is a longer note with some interesting content that will be truncated when generating a preview. The preview should show only the first few hundred characters and end with an ellipsis.</div></en-note>',
+  content:
+    '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>This is a longer note with some interesting content that will be truncated when generating a preview. The preview should show only the first few hundred characters and end with an ellipsis.</div></en-note>',
   created: Date.now(),
   updated: Date.now(),
 };
@@ -278,13 +284,13 @@ export const resetMocks = () => {
       mock.mockClear();
     }
   });
-  
+
   Object.values(mockUserStore).forEach((mock: any) => {
     if (jest.isMockFunction(mock)) {
       mock.mockClear();
     }
   });
-  
+
   mockEvernoteClient.getNoteStore.mockClear();
   mockEvernoteClient.getUserStore.mockClear();
 };

--- a/__tests__/unit/polling.test.ts
+++ b/__tests__/unit/polling.test.ts
@@ -1,0 +1,112 @@
+import {
+  buildSyncChunkFilter,
+  buildWebhookPayload,
+  checkForPollingChanges,
+} from '../../src/polling';
+
+describe('Evernote polling', () => {
+  it('fetches filtered sync chunks and converts note changes', async () => {
+    const evernoteApi = {
+      getSyncState: jest.fn().mockResolvedValue({ updateCount: 15 }),
+      getFilteredSyncChunk: jest.fn().mockResolvedValue({
+        notes: [
+          {
+            guid: 'note-new',
+            title: 'New note',
+            notebookGuid: 'notebook-1',
+            created: 1000,
+            updated: 1000,
+          },
+          {
+            guid: 'note-updated',
+            title: 'Updated note',
+            notebookGuid: 'notebook-1',
+            created: 1000,
+            updated: 2000,
+          },
+        ],
+      }),
+    };
+
+    const result = await checkForPollingChanges({
+      evernoteApi,
+      lastUpdateCount: 10,
+      now: () => new Date('2026-05-22T10:00:00.000Z'),
+    });
+
+    expect(evernoteApi.getFilteredSyncChunk).toHaveBeenCalledWith(
+      10,
+      100,
+      expect.objectContaining({
+        includeNotes: true,
+        includeNotebooks: true,
+        includeTags: true,
+        includeExpunged: true,
+      }),
+    );
+    expect(result.nextUpdateCount).toBe(15);
+    expect(result.changes).toEqual([
+      {
+        type: 'note_created',
+        guid: 'note-new',
+        title: 'New note',
+        notebookGuid: 'notebook-1',
+        timestamp: '1970-01-01T00:00:01.000Z',
+      },
+      {
+        type: 'note_updated',
+        guid: 'note-updated',
+        title: 'Updated note',
+        notebookGuid: 'notebook-1',
+        timestamp: '1970-01-01T00:00:02.000Z',
+      },
+    ]);
+  });
+
+  it('keeps the previous update count when chunk fetching fails', async () => {
+    const evernoteApi = {
+      getSyncState: jest.fn().mockResolvedValue({ updateCount: 15 }),
+      getFilteredSyncChunk: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    const result = await checkForPollingChanges({
+      evernoteApi,
+      lastUpdateCount: 10,
+    });
+
+    expect(result.nextUpdateCount).toBe(10);
+    expect(result.error?.message).toBe('boom');
+    expect(result.changes).toEqual([]);
+  });
+
+  it('builds the MCP webhook payload for one change at a time', () => {
+    const change = {
+      type: 'note_created' as const,
+      guid: 'note-1',
+      title: 'Note 1',
+      timestamp: '2026-05-22T10:00:00.000Z',
+    };
+
+    expect(
+      buildWebhookPayload(change, () => new Date('2026-05-22T10:01:00.000Z')),
+    ).toEqual({
+      source: 'mcp-evernote',
+      timestamp: '2026-05-22T10:01:00.000Z',
+      changes: [change],
+    });
+  });
+
+  it('uses the SDK-supported filtered sync chunk shape', () => {
+    expect(buildSyncChunkFilter()).toEqual({
+      includeNotes: true,
+      includeNoteResources: false,
+      includeNoteAttributes: false,
+      includeNotebooks: true,
+      includeTags: true,
+      includeSearches: false,
+      includeResources: false,
+      includeLinkedNotebooks: false,
+      includeExpunged: true,
+    });
+  });
+});

--- a/src/evernote-api.ts
+++ b/src/evernote-api.ts
@@ -522,8 +522,16 @@ export class EvernoteAPI {
     return await this.noteStore.getSyncState();
   }
 
-  async getSyncChunk(afterUSN: number, maxEntries: number = 100, fullSyncOnly: boolean = false): Promise<any> {
-    return await this.noteStore.getSyncChunk(afterUSN, maxEntries, fullSyncOnly);
+  async getFilteredSyncChunk(afterUSN: number, maxEntries: number = 100, filter: any): Promise<any> {
+    const EvernoteModule = (Evernote as any).default || Evernote;
+    const SyncChunkFilter = EvernoteModule.NoteStore?.SyncChunkFilter;
+    const sdkFilter = SyncChunkFilter ? new SyncChunkFilter(filter) : filter;
+
+    return await this.noteStore.getFilteredSyncChunk(
+      afterUSN,
+      maxEntries,
+      sdkFilter
+    );
   }
 
   // Helper methods

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ async function checkForChanges(): Promise<PollingChange[]> {
     }
 
     console.error(
-      `Polling: Changes detected! Getting sync chunk from USN ${previousUpdateCount}...`
+      `Polling: Changes detected since USN ${previousUpdateCount}`
     );
 
     if (result.error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ import { EvernoteAPI } from './evernote-api.js';
 import { EvernoteConfig } from './types.js';
 import { validateToolArgs } from './tool-schemas.js';
 import { computeWebhookSignature } from './webhook.js';
+import {
+  PollingChange,
+  buildWebhookPayload,
+  checkForPollingChanges,
+} from './polling.js';
 
 // Load environment variables
 config();
@@ -123,14 +128,6 @@ async function ensureAPI(forceReinit: boolean = false): Promise<EvernoteAPI> {
 // Polling for Changes
 // ============================================================================
 
-interface PollingChange {
-  type: 'note_created' | 'note_updated' | 'note_deleted' | 'notebook_changed' | 'tag_changed';
-  guid?: string;
-  title?: string;
-  notebookGuid?: string;
-  timestamp: string;
-}
-
 async function sendWebhookNotification(changes: PollingChange[]): Promise<void> {
   if (!WEBHOOK_URL) {
     console.error('No webhook URL configured, skipping notification');
@@ -144,11 +141,7 @@ async function sendWebhookNotification(changes: PollingChange[]): Promise<void> 
   // Send one webhook per change for cleaner workflow processing
   for (const change of changes) {
     try {
-      const body = JSON.stringify({
-        source: 'mcp-evernote',
-        timestamp: new Date().toISOString(),
-        changes: [change], // Single change per webhook
-      });
+      const body = JSON.stringify(buildWebhookPayload(change));
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -181,92 +174,55 @@ async function sendWebhookNotification(changes: PollingChange[]): Promise<void> 
 }
 
 async function checkForChanges(): Promise<PollingChange[]> {
-  const changes: PollingChange[] = [];
-  
   try {
     const evernoteApi = await ensureAPI();
-    const syncState = await evernoteApi.getSyncState();
-    const currentUpdateCount = syncState.updateCount;
-    
-    console.error(`Polling: Current updateCount = ${currentUpdateCount}, last = ${lastUpdateCount}`);
-    
+    const previousUpdateCount = lastUpdateCount;
+    const result = await checkForPollingChanges({
+      evernoteApi,
+      lastUpdateCount,
+    });
+
+    console.error(
+      `Polling: Current updateCount = ${result.currentUpdateCount}, last = ${previousUpdateCount}`
+    );
+
     // First run - just store the count
-    if (lastUpdateCount === null) {
-      lastUpdateCount = currentUpdateCount;
+    if (previousUpdateCount === null) {
+      lastUpdateCount = result.nextUpdateCount;
+      pollErrorCount = 0;
       console.error('Polling: Initial sync state captured');
-      return changes;
+      return result.changes;
     }
-    
+
     // No changes
-    if (currentUpdateCount === lastUpdateCount) {
+    if (result.currentUpdateCount === previousUpdateCount) {
+      lastUpdateCount = result.nextUpdateCount;
+      pollErrorCount = 0;
       console.error('Polling: No changes detected');
-      return changes;
+      return result.changes;
     }
-    
-    // Changes detected - get the sync chunk to see what changed
-    console.error(`Polling: Changes detected! Getting sync chunk from USN ${lastUpdateCount}...`);
-    
-    try {
-      const chunk = await evernoteApi.getSyncChunk(lastUpdateCount, 100, false);
-      
-      // Process notes
-      if (chunk.notes && chunk.notes.length > 0) {
-        for (const note of chunk.notes) {
-          const isNew = note.created === note.updated;
-          changes.push({
-            type: isNew ? 'note_created' : 'note_updated',
-            guid: note.guid,
-            title: note.title,
-            notebookGuid: note.notebookGuid,
-            timestamp: new Date(note.updated).toISOString(),
-          });
-        }
+
+    console.error(
+      `Polling: Changes detected! Getting sync chunk from USN ${previousUpdateCount}...`
+    );
+
+    if (result.error) {
+      console.error(`Polling: Failed to get sync chunk: ${result.error.message}`);
+      pollErrorCount++;
+
+      if (pollErrorCount >= 5) {
+        console.error('Polling: Too many errors, stopping polling');
+        stopPolling();
       }
-      
-      // Process expunged notes (deleted)
-      if (chunk.expungedNotes && chunk.expungedNotes.length > 0) {
-        for (const guid of chunk.expungedNotes) {
-          changes.push({
-            type: 'note_deleted',
-            guid,
-            timestamp: new Date().toISOString(),
-          });
-        }
-      }
-      
-      // Process notebooks
-      if (chunk.notebooks && chunk.notebooks.length > 0) {
-        for (const notebook of chunk.notebooks) {
-          changes.push({
-            type: 'notebook_changed',
-            guid: notebook.guid,
-            title: notebook.name,
-            timestamp: new Date().toISOString(),
-          });
-        }
-      }
-      
-      // Process tags
-      if (chunk.tags && chunk.tags.length > 0) {
-        for (const tag of chunk.tags) {
-          changes.push({
-            type: 'tag_changed',
-            guid: tag.guid,
-            title: tag.name,
-            timestamp: new Date().toISOString(),
-          });
-        }
-      }
-      
-      console.error(`Polling: Found ${changes.length} changes`);
-    } catch (chunkError: any) {
-      console.error(`Polling: Failed to get sync chunk: ${chunkError.message}`);
-      // Still update the count to avoid re-processing
+
+      lastUpdateCount = result.nextUpdateCount;
+      return result.changes;
     }
-    
-    lastUpdateCount = currentUpdateCount;
-    return changes;
-    
+
+    lastUpdateCount = result.nextUpdateCount;
+    pollErrorCount = 0;
+    console.error(`Polling: Found ${result.changes.length} changes`);
+    return result.changes;
   } catch (error: any) {
     console.error(`Polling error: ${error.message}`);
     pollErrorCount++;
@@ -277,13 +233,12 @@ async function checkForChanges(): Promise<PollingChange[]> {
       stopPolling();
     }
     
-    return changes;
+    return [];
   }
 }
 
 async function pollOnce(): Promise<PollingChange[]> {
   lastPollTime = Date.now();
-  pollErrorCount = 0; // Reset on successful poll attempt
   
   const changes = await checkForChanges();
   

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -1,0 +1,182 @@
+export type PollingChangeType =
+  | 'note_created'
+  | 'note_updated'
+  | 'note_deleted'
+  | 'notebook_changed'
+  | 'tag_changed';
+
+export interface PollingChange {
+  type: PollingChangeType;
+  guid?: string;
+  title?: string;
+  notebookGuid?: string;
+  timestamp: string;
+}
+
+export interface SyncChunkFilterShape {
+  includeNotes: boolean;
+  includeNoteResources: boolean;
+  includeNoteAttributes: boolean;
+  includeNotebooks: boolean;
+  includeTags: boolean;
+  includeSearches: boolean;
+  includeResources: boolean;
+  includeLinkedNotebooks: boolean;
+  includeExpunged: boolean;
+}
+
+export interface PollingCheckResult {
+  changes: PollingChange[];
+  currentUpdateCount: number;
+  nextUpdateCount: number | null;
+  error?: Error;
+}
+
+interface PollingEvernoteApi {
+  getSyncState(): Promise<{ updateCount: number }>;
+  getFilteredSyncChunk(
+    afterUSN: number,
+    maxEntries: number,
+    filter: SyncChunkFilterShape
+  ): Promise<{
+    notes?: Array<{
+      guid?: string;
+      title?: string;
+      notebookGuid?: string;
+      created?: number;
+      updated?: number;
+    }>;
+    expungedNotes?: string[];
+    notebooks?: Array<{ guid?: string; name?: string }>;
+    tags?: Array<{ guid?: string; name?: string }>;
+  }>;
+}
+
+interface CheckForPollingChangesOptions {
+  evernoteApi: PollingEvernoteApi;
+  lastUpdateCount: number | null;
+  maxEntries?: number;
+  now?: () => Date;
+}
+
+export function buildSyncChunkFilter(): SyncChunkFilterShape {
+  return {
+    includeNotes: true,
+    includeNoteResources: false,
+    includeNoteAttributes: false,
+    includeNotebooks: true,
+    includeTags: true,
+    includeSearches: false,
+    includeResources: false,
+    includeLinkedNotebooks: false,
+    includeExpunged: true,
+  };
+}
+
+export function buildWebhookPayload(
+  change: PollingChange,
+  now: () => Date = () => new Date()
+): {
+  source: 'mcp-evernote';
+  timestamp: string;
+  changes: PollingChange[];
+} {
+  return {
+    source: 'mcp-evernote',
+    timestamp: now().toISOString(),
+    changes: [change],
+  };
+}
+
+export async function checkForPollingChanges({
+  evernoteApi,
+  lastUpdateCount,
+  maxEntries = 100,
+  now = () => new Date(),
+}: CheckForPollingChangesOptions): Promise<PollingCheckResult> {
+  const syncState = await evernoteApi.getSyncState();
+  const currentUpdateCount = syncState.updateCount;
+
+  if (lastUpdateCount === null || currentUpdateCount === lastUpdateCount) {
+    return {
+      changes: [],
+      currentUpdateCount,
+      nextUpdateCount: currentUpdateCount,
+    };
+  }
+
+  try {
+    const chunk = await evernoteApi.getFilteredSyncChunk(
+      lastUpdateCount,
+      maxEntries,
+      buildSyncChunkFilter()
+    );
+
+    return {
+      changes: changesFromSyncChunk(chunk, now),
+      currentUpdateCount,
+      nextUpdateCount: currentUpdateCount,
+    };
+  } catch (error: unknown) {
+    return {
+      changes: [],
+      currentUpdateCount,
+      nextUpdateCount: lastUpdateCount,
+      error: normalizeError(error),
+    };
+  }
+}
+
+function changesFromSyncChunk(
+  chunk: Awaited<ReturnType<PollingEvernoteApi['getFilteredSyncChunk']>>,
+  now: () => Date
+): PollingChange[] {
+  const changes: PollingChange[] = [];
+
+  for (const note of chunk.notes || []) {
+    const updated = note.updated || now().getTime();
+    changes.push({
+      type: note.created === note.updated ? 'note_created' : 'note_updated',
+      guid: note.guid,
+      title: note.title,
+      notebookGuid: note.notebookGuid,
+      timestamp: new Date(updated).toISOString(),
+    });
+  }
+
+  for (const guid of chunk.expungedNotes || []) {
+    changes.push({
+      type: 'note_deleted',
+      guid,
+      timestamp: now().toISOString(),
+    });
+  }
+
+  for (const notebook of chunk.notebooks || []) {
+    changes.push({
+      type: 'notebook_changed',
+      guid: notebook.guid,
+      title: notebook.name,
+      timestamp: now().toISOString(),
+    });
+  }
+
+  for (const tag of chunk.tags || []) {
+    changes.push({
+      type: 'tag_changed',
+      guid: tag.guid,
+      title: tag.name,
+      timestamp: now().toISOString(),
+    });
+  }
+
+  return changes;
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -178,5 +178,20 @@ function normalizeError(error: unknown): Error {
     return error;
   }
 
-  return new Error(String(error));
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string') {
+      return new Error(message);
+    }
+  }
+
+  try {
+    return new Error(JSON.stringify(error));
+  } catch {
+    return new Error(String(error));
+  }
 }


### PR DESCRIPTION
## Summary
- replace unsupported Evernote SDK getSyncChunk polling with getFilteredSyncChunk
- add a reusable polling helper that builds filtered sync chunk requests and one-change webhook payloads
- keep lastUpdateCount unchanged when sync chunk fetching fails so changes are retried instead of dropped

## Tests
- npm run lint
- npm run build
- npm test -- --runTestsByPath __tests__/unit/polling.test.ts __tests__/unit/tool-schemas.test.ts __tests__/unit/webhook-hmac.test.ts
- npm test -- --runTestsByPath __tests__/unit/polling.test.ts

## Breaking Changes
None.