### PR TITLE
fix: resolve noteStoreUrl via getUserUrls() (SDK has no getNoteStoreUrl)

### DIFF
--- a/src/auth-standalone.ts
+++ b/src/auth-standalone.ts
@@ -183,13 +183,18 @@ async function performOAuth(credentials: Credentials) {
               china: false
             });
             
-            const noteStoreUrl = authenticatedClient.getNoteStore().url;
-            
             // Get user info to verify token
             try {
               const userStore = authenticatedClient.getUserStore();
               const user = await userStore.getUser();
-              
+              // getNoteStore().url is undefined here; getUserUrls() returns the
+              // real noteStoreUrl, falling back to deriving from webApiUrlPrefix.
+              const userUrls = await userStore.getUserUrls();
+              const noteStoreUrl = userUrls?.noteStoreUrl
+                || (results.edam_webApiUrlPrefix
+                  ? results.edam_webApiUrlPrefix.replace(/\/$/, '') + '/notestore'
+                  : undefined);
+
               const tokenData = {
                 token: accessToken,
                 noteStoreUrl,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -175,7 +175,16 @@ export class EvernoteOAuth {
     if (!tokens.noteStoreUrl) {
       try {
         const userStore = authenticatedClient.getUserStore();
-        const noteStoreUrl = await userStore.getNoteStoreUrl();
+        // The Evernote JS SDK (evernote@2.0.5) has no getNoteStoreUrl(); use
+        // getUserUrls(), and fall back to deriving from webApiUrlPrefix.
+        const userUrls = await userStore.getUserUrls();
+        const noteStoreUrl = userUrls?.noteStoreUrl
+          || (tokens.webApiUrlPrefix
+            ? tokens.webApiUrlPrefix.replace(/\/$/, '') + '/notestore'
+            : undefined);
+        if (!noteStoreUrl) {
+          throw new Error('UserStore returned no noteStoreUrl');
+        }
         tokens.noteStoreUrl = noteStoreUrl;
         if (!process.env.EVERNOTE_ACCESS_TOKEN && !(this.isClaudeCode && process.env.OAUTH_TOKEN)) {
           await fs.writeFile(this.tokenFile, JSON.stringify(tokens, null, 2));


### PR DESCRIPTION
## Problem

With file-based auth (`.evernote-token.json`, i.e. the Claude Desktop / non-env-var path), **every tool call fails** with:

```
Not connected: Failed to get noteStoreUrl from Evernote. Token may be invalid.
```

The token isn't actually invalid. Root cause is a method that doesn't exist in the bundled SDK:

- **Read side** (`src/oauth.ts`): when a loaded token has no cached `noteStoreUrl`, `getAuthenticatedClient()` calls `userStore.getNoteStoreUrl()`. **`evernote@2.0.5` has no `getNoteStoreUrl()` method** — UserStore exposes `getUser`, `getUserUrls`, `getPublicUserInfo`, etc. The call throws and gets rethrown as the misleading "Token may be invalid".
- **Write side** (`src/auth-standalone.ts`): `authenticatedClient.getNoteStore().url` returns `undefined`, so the standalone OAuth flow persists a token file with `noteStoreUrl` unset — guaranteeing the read-side failure on the next run.

Env-var auth (`EVERNOTE_NOTESTORE_URL` / `OAUTH_NOTESTORE_URL`) supplies the URL directly and so masks the bug, which is likely why it's gone unnoticed.

## Fix

Use the real SDK method `userStore.getUserUrls().noteStoreUrl`, with a fallback that derives it from `webApiUrlPrefix` (`<prefix>/notestore`). Applied on both the read and write paths.

## Verification

Tested against a live production account:

- Token file with **no** `noteStoreUrl` → server now fetches successfully and returns notes (715 results on a `travel` search), and persists the resolved `noteStoreUrl` back to the token file.
- `userStore.getUserUrls().noteStoreUrl` returns `https://www.evernote.com/shard/sXXX/notestore`, matching the derived fallback.
- `npm run build` (tsc) clean; eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)